### PR TITLE
Default to whatever language Travis uses for Docker builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,3 @@
-language: go
-
-go:
-  - 1.8
-
 sudo: required
 
 services:
@@ -18,7 +13,7 @@ script:
   - docker build -t "quay.io/pires/nats-operator:${TRAVIS_TAG:-latest}" .
 
 after_success:
-  - if [[ "${TRAVIS_BRANCH}" == "master" ]] || [[ "${TRAVIS_TAG}" != "" ]];
+  - if ([[ "${TRAVIS_BRANCH}" == "master" ]] && [[ "${TRAVIS_PULL_REQUEST}" == "false" ]]) || [[ "${TRAVIS_TAG}" != "" ]];
     then
         docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}" quay.io;
         docker push "quay.io/pires/nats-operator:${TRAVIS_TAG:-latest}";


### PR DESCRIPTION
I had set the language to Go because, well, this is a Go project — although in fact we're only building a Docker image.

This makes Travis use whatever base image it uses for building Docker images (which currently happens to be Ruby). This prevents Travis from trying to install Go dependencies, which was the root cause for the failure.

Please note that, in case you haven't done it yet, you will have to set up a robot account at Quay and setup its credentials on Travis (`DOCKER_USERNAME` and `DOCKER_PASSWORD`).